### PR TITLE
Create Dockerfile to make deployment easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build FediUni binary.
+FROM golang:alpine AS build
+
+WORKDIR /app
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /fediuni
+
+# Deploy FediUni binary.
+FROM alpine:latest
+WORKDIR /
+COPY --from=build /fediuni /fediuni
+EXPOSE 8080
+ENTRYPOINT ["/fediuni"]


### PR DESCRIPTION
Closes #5.
Add a Dockerfile which uses multistage builds to create an image.