### PR TITLE
Compare against PublicKeyPEM before decoding block

### DIFF
--- a/activitypub/actor/actor.go
+++ b/activitypub/actor/actor.go
@@ -40,13 +40,13 @@ type Person struct {
 	PublicKey *PublicKey
 }
 
-type RSAKeyGenerator struct {
+type PKCS1KeyGenerator struct {
 	privateKey *bytes.Buffer
 	publicKey  *bytes.Buffer
 }
 
-func NewRSAKeyGenerator() *RSAKeyGenerator {
-	return &RSAKeyGenerator{
+func NewPKCS1KeyGenerator() *PKCS1KeyGenerator {
+	return &PKCS1KeyGenerator{
 		privateKey: &bytes.Buffer{},
 		publicKey:  &bytes.Buffer{},
 	}
@@ -93,7 +93,7 @@ func NewPerson(username, displayName, baseURL string, keyGenerator KeyGenerator)
 	return person, nil
 }
 
-func (g *RSAKeyGenerator) GenerateKeyPair() (string, string, error) {
+func (g *PKCS1KeyGenerator) GenerateKeyPair() (string, string, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to generate private key: got err=%v", err)
@@ -113,7 +113,7 @@ func (g *RSAKeyGenerator) GenerateKeyPair() (string, string, error) {
 	return g.privateKey.String(), g.publicKey.String(), nil
 }
 
-func (g *RSAKeyGenerator) WritePrivateKey(privateKeyPath string) error {
+func (g *PKCS1KeyGenerator) WritePrivateKey(privateKeyPath string) error {
 	privatePem, err := os.Create(privateKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to create private pem file: got err=%v", err)

--- a/activitypub/server_test.go
+++ b/activitypub/server_test.go
@@ -20,7 +20,7 @@ type TestDatastore struct {
 }
 
 func NewTestDatastore(url string) *TestDatastore {
-	keyGenerator := actor.NewRSAKeyGenerator()
+	keyGenerator := actor.NewPKCS1KeyGenerator()
 	privateKey, publicKey, _ := keyGenerator.GenerateKeyPair()
 	return &TestDatastore{
 		knownUsers: map[string]*actor.Person{

--- a/activitypub/signature/key.go
+++ b/activitypub/signature/key.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"strings"
 )
 
 // parsePublicKeyFromPEMBlock determines the RSA Public Key from PEM.
@@ -14,17 +13,13 @@ func parsePublicKeyFromPEMBlock(publicKeyPEM string) (*rsa.PublicKey, error) {
 	if block == nil {
 		return nil, fmt.Errorf("failed to decode public key from pem")
 	}
-	if strings.HasPrefix(publicKeyPEM, "-----BEGIN RSA PUBLIC KEY-----") {
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
 		publicKey, err := x509.ParsePKCS1PublicKey(block.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse public key from block: got err=%v", err)
-
 		}
 		return publicKey, nil
-	}
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key from block: got err=%v", err)
 	}
 	switch pub.(type) {
 	case *rsa.PublicKey:

--- a/activitypub/signature/request_test.go
+++ b/activitypub/signature/request_test.go
@@ -23,7 +23,7 @@ func TestSignRequest(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			privateKey, publicKey, err := actor.NewRSAKeyGenerator().GenerateKeyPair()
+			privateKey, publicKey, err := actor.NewPKCS1KeyGenerator().GenerateKeyPair()
 			if err != nil {
 				t.Errorf("Failed to generate private key: got err=%v", err)
 			}

--- a/activitypub/signature/validate_test.go
+++ b/activitypub/signature/validate_test.go
@@ -64,16 +64,18 @@ func TestProcessSignatureHeader(t *testing.T) {
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name           string
+		keyGenerator   *actor.PKCS1KeyGenerator
 		wantStatusCode int
 	}{
 		{
-			name:           "Test validate request with valid signature",
+			name:           "Test validate request with valid signature (PKCS1)",
+			keyGenerator:   actor.NewPKCS1KeyGenerator(),
 			wantStatusCode: 200,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			privateKey, publicKey, err := actor.NewRSAKeyGenerator().GenerateKeyPair()
+			privateKey, publicKey, err := test.keyGenerator.GenerateKeyPair()
 			if err != nil {
 				t.Errorf("Failed to generate private key: got err=%v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	s, err := activitypub.NewServer(instanceURL, *keys, datastore, actor.NewRSAKeyGenerator())
+	s, err := activitypub.NewServer(instanceURL, *keys, datastore, actor.NewPKCS1KeyGenerator())
 	if err != nil {
 		log.Fatalf("failed to create service: got err=%v", err)
 	}


### PR DESCRIPTION
Avoid panicking when receiving public key. Try and correct issues with verifying signatures.