### PR TITLE
Fix follow object actor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,7 @@ workflows:
     jobs:
       - buildandtest:
           context: COVERALLS_TOKEN
-      - buildimage:
-          filters:
-            branches:
-              only:
-                - main
+      - buildimage
       - publish:
           requires:
             - buildimage

--- a/activitypub/server.go
+++ b/activitypub/server.go
@@ -275,13 +275,7 @@ func (s *Server) acceptFollower(ctx context.Context, follow vocab.ActivityStream
 	if err != nil {
 		return err
 	}
-	if follow.GetActivityStreamsActor().Empty() {
-		return fmt.Errorf("follow request failed to provide an actor")
-	}
-	if !follow.GetActivityStreamsActor().Begin().IsActivityStreamsPerson() {
-		return fmt.Errorf("actors other than person is unsupported")
-	}
-	personID := follow.GetActivityStreamsActor().Begin().GetActivityStreamsPerson().GetJSONLDId()
+	personID := follow.GetActivityStreamsObject().Begin().GetActivityStreamsPerson().GetJSONLDId()
 	actor, err := s.Datastore.GetActorByActorID(ctx, personID.GetIRI().String())
 	if err != nil {
 		return fmt.Errorf("failed to load person: got err=%v", err)


### PR DESCRIPTION
Actor following was broken due to the Actor in a follow request corresponding to the person initiating the follow rather than the "Actor to be followed" which was the actor. #44 