### PR TITLE
Define public Inbox route and forward public create activities

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 type TestDatastore struct {
+	Datastore
 	knownUsers  map[string]*user.User
 	knownActors map[string]actor.Person
 	privateKeys map[string]string
@@ -63,7 +64,7 @@ func (d *TestDatastore) CreateUser(_ context.Context, user *user.User) error {
 	return nil
 }
 
-func (d *TestDatastore) AddActivityToPublicInbox(_ context.Context, _ vocab.Type, _ primitive.ObjectID) error {
+func (d *TestDatastore) AddActivityToPublicInbox(_ context.Context, _ vocab.Type, _ primitive.ObjectID, b bool) error {
 	return fmt.Errorf("AddActivityToPublicInbox() is unimplemented")
 }
 


### PR DESCRIPTION
Public Inbox now exists

Any public activity received to an actor inbox is also saved in the public inbox and tagged isLocal or isReply appropriately.